### PR TITLE
adding a null default to the gcp_bindings variable

### DIFF
--- a/gcp_variables.tf
+++ b/gcp_variables.tf
@@ -47,5 +47,6 @@ variable "gcp_bindings" {
     roles    = list(string)
   }))
   description = "Bindings to create for this roleset."
+  default = null
 }
 

--- a/gcp_variables.tf
+++ b/gcp_variables.tf
@@ -47,6 +47,6 @@ variable "gcp_bindings" {
     roles    = list(string)
   }))
   description = "Bindings to create for this roleset."
-  default = null
+  default     = null
 }
 


### PR DESCRIPTION
Without a null default in the gcp_bindings variable, there is an error whenever configuring any other secrets engine as it's looking for for that value of that variable.  This PR fixes that